### PR TITLE
Update device_tracker config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ device_tracker:
     host: <IP OF ROUTER>
     username: Admin
     password: <PASSWORD>
-    track_new_devices: no
+    new_device_defaults:
+      track_new_devices: False
+      hide_if_away: False
 ```
+
+More info on how to configure/use tracked devices can be found [here](https://www.home-assistant.io/components/device_tracker/).
 
 ## Contributing
 


### PR DESCRIPTION
The newer versions of HA have slightly different requirements for the device tracker. There is now a parameter for `new_device_defaults`. For me the device tracker didn't work until I used this parameter to set defaults for new devices.